### PR TITLE
Fix TypeORM env config

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
-DB_PASSWORD=postgres
-DB_NAME=ulgen
+DB_PASSWORD=123456
+DB_NAME=ulgen_db
 JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ulgen/
 ### Backend
 1. `cd backend`
 2. Install deps with `npm install`
-3. Copy `.env.example` to `.env` and configure PostgreSQL settings
+3. Copy `.env.example` to `.env` and configure the `DB_*` variables
 4. Run with `npm run start:dev`
 
 The API will start on `http://localhost:3000` and Swagger docs are available at
@@ -32,4 +32,5 @@ The API will start on `http://localhost:3000` and Swagger docs are available at
 The app will be served on `http://localhost:5173`.
 
 ## Environment Variables
-See `.env.example` for required variables.
+See `.env.example` for required variables such as `DB_HOST`, `DB_PORT`,
+`DB_USERNAME`, `DB_PASSWORD` and `DB_NAME`.

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -1,21 +1,25 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TodoModule } from './to_do/todo.module';
 import { TodoEntity } from './to_do/todo.entity';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
-    TypeOrmModule.forRoot({
-      type: 'postgres',
-      host: process.env.DATABASE_HOST,
-      port: parseInt(process.env.DATABASE_PORT || '5432', 10),
-      username: process.env.DATABASE_USER,
-      password: process.env.DATABASE_PASSWORD,
-      database: process.env.DATABASE_NAME,
-      entities: [TodoEntity],
-      synchronize: true,
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        type: 'postgres',
+        host: config.get<string>('DB_HOST'),
+        port: parseInt(config.get<string>('DB_PORT', '5432'), 10),
+        username: config.get<string>('DB_USERNAME'),
+        password: config.get<string>('DB_PASSWORD'),
+        database: config.get<string>('DB_NAME'),
+        entities: [TodoEntity],
+        synchronize: true,
+      }),
     }),
     TodoModule,
   ],


### PR DESCRIPTION
## Summary
- configure TypeORM through `ConfigService`
- document DB_* variables in README
- provide example env file with DB vars
- add default `.env` for local development

## Testing
- `npm install`
- `npm run start:dev` *(fails to connect because DB isn't running but TypeORM loads config)*

------
https://chatgpt.com/codex/tasks/task_e_6847273e9190832c94fdf4a4e54c29af