### PR TITLE
Add Swagger metadata for todos

### DIFF
--- a/backend/src/todo/dto/create-todo.dto.ts
+++ b/backend/src/todo/dto/create-todo.dto.ts
@@ -1,4 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateTodoDto {
+  @ApiProperty({ example: 'Buy milk', description: 'Title of the todo item' })
   title: string;
+
+  @ApiProperty({ example: false, description: 'Completion status', required: false })
   completed?: boolean;
 }

--- a/backend/src/todo/todo.controller.ts
+++ b/backend/src/todo/todo.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Body, Req } from '@nestjs/common';
+import { ApiQuery } from '@nestjs/swagger';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 
@@ -12,6 +13,7 @@ export class TodoController {
   }
 
   @Get()
+  @ApiQuery({ name: 'tenantId', required: true, description: 'Tenant ID for multi-tenant isolation' })
   findAll(@Req() req: any) {
     return this.todoService.findAll(req.tenantId);
   }


### PR DESCRIPTION
## Summary
- document CreateTodoDto fields with examples in Swagger
- annotate GET /todos with tenantId query parameter

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68570fbee34c832cbcb44fd2f7fda2cf