### PR TITLE
Expose tenantId query param in Swagger

### DIFF
--- a/backend/src/todo/todo.controller.ts
+++ b/backend/src/todo/todo.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, ParseIntPipe } from '@nestjs/common';
 import { ApiQuery } from '@nestjs/swagger';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
@@ -8,14 +8,17 @@ export class TodoController {
   constructor(private readonly todoService: TodoService) {}
 
   @Post()
-  @ApiQuery({ name: 'tenantId', required: true, description: 'Tenant ID for multi-tenant isolation' })
-  create(@Body() dto: CreateTodoDto, @Query('tenantId') tenantId: string) {
-    return this.todoService.create(dto, Number(tenantId));
+  @ApiQuery({ name: 'tenantId', required: true, type: Number, description: 'Tenant ID for multi-tenant isolation' })
+  create(
+    @Body() dto: CreateTodoDto,
+    @Query('tenantId', ParseIntPipe) tenantId: number,
+  ) {
+    return this.todoService.create(dto, tenantId);
   }
 
   @Get()
-  @ApiQuery({ name: 'tenantId', required: true, description: 'Tenant ID for multi-tenant isolation' })
-  findAll(@Query('tenantId') tenantId: string) {
-    return this.todoService.findAll(Number(tenantId));
+  @ApiQuery({ name: 'tenantId', required: true, type: Number, description: 'Tenant ID for multi-tenant isolation' })
+  findAll(@Query('tenantId', ParseIntPipe) tenantId: number) {
+    return this.todoService.findAll(tenantId);
   }
 }


### PR DESCRIPTION
## Summary
- show tenantId as a numeric query parameter on `/todos` endpoints

## Testing
- `npx tsc`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685716482c40832c9315cebf9730460e