### PR TITLE
Fix tenantId handling in todo creation

### DIFF
--- a/backend/src/todo/todo.controller.ts
+++ b/backend/src/todo/todo.controller.ts
@@ -8,12 +8,18 @@ export class TodoController {
   constructor(private readonly todoService: TodoService) {}
 
   @Post()
-  @ApiQuery({ name: 'tenantId', required: true, type: Number, description: 'Tenant ID for multi-tenant isolation' })
+  @ApiQuery({
+    name: 'tenantId',
+    required: false,
+    type: Number,
+    description: 'Tenant ID for multi-tenant isolation',
+  })
   create(
     @Body() dto: CreateTodoDto,
-    @Query('tenantId', ParseIntPipe) tenantId: number,
+    @Query('tenantId', ParseIntPipe) tenantId?: number,
   ) {
-    return this.todoService.create(dto, tenantId);
+    const tid = tenantId ?? 1;
+    return this.todoService.create({ ...dto, tenantId: tid });
   }
 
   @Get()

--- a/backend/src/todo/todo.service.ts
+++ b/backend/src/todo/todo.service.ts
@@ -11,8 +11,8 @@ export class TodoService {
     private readonly repo: Repository<Todo>,
   ) {}
 
-  create(dto: CreateTodoDto, tenantId: number) {
-    const todo = this.repo.create({ ...dto, tenantId });
+  create(dto: CreateTodoDto & { tenantId: number }) {
+    const todo = this.repo.create(dto);
     return this.repo.save(todo);
   }
 


### PR DESCRIPTION
## Summary
- support optional `tenantId` for POST /todos
- default to tenant 1 when not provided
- include tenantId in service create logic

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857185496d4832c844110dc6086ea16