### PR TITLE
Fix optional tenantId in todo creation

### DIFF
--- a/backend/src/todo/todo.controller.ts
+++ b/backend/src/todo/todo.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Query, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
 import { ApiQuery } from '@nestjs/swagger';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
@@ -16,10 +24,9 @@ export class TodoController {
   })
   create(
     @Body() dto: CreateTodoDto,
-    @Query('tenantId', ParseIntPipe) tenantId?: number,
+    @Query('tenantId', new DefaultValuePipe(1), ParseIntPipe) tenantId: number,
   ) {
-    const tid = tenantId ?? 1;
-    return this.todoService.create({ ...dto, tenantId: tid });
+    return this.todoService.create({ ...dto, tenantId });
   }
 
   @Get()


### PR DESCRIPTION
## Summary
- make tenantId optional in POST /todos
- remove unreachable code and duplicate query decorators

## Testing
- `npm install`
- `npm run build` *(fails: nest not found previously; after installing dev deps, compile succeeds)*
- `curl -X POST "http://localhost:3000/todos?tenantId=1" -H "Content-Type: application/json" -d '{"title": "Buy milk", "completed": false}'` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68571b48dd08832c886b2a5e32773f9c