### PR TITLE
Fix tenantId default on todo creation

### DIFF
--- a/backend/src/todo/todo.controller.ts
+++ b/backend/src/todo/todo.controller.ts
@@ -5,7 +5,6 @@ import {
   Body,
   Query,
   ParseIntPipe,
-  DefaultValuePipe,
 } from '@nestjs/common';
 import { ApiQuery } from '@nestjs/swagger';
 import { TodoService } from './todo.service';
@@ -24,9 +23,10 @@ export class TodoController {
   })
   create(
     @Body() dto: CreateTodoDto,
-    @Query('tenantId', new DefaultValuePipe(1), ParseIntPipe) tenantId: number,
+    @Query('tenantId', ParseIntPipe) tenantId?: number,
   ) {
-    return this.todoService.create({ ...dto, tenantId });
+    const tid = tenantId ?? 1;
+    return this.todoService.create({ ...dto, tenantId: tid });
   }
 
   @Get()


### PR DESCRIPTION
## Summary
- ensure POST `/todos` allows optional tenantId query param
- default tenantId to `1` when missing

## Testing
- `npm --prefix backend install`
- `npx tsc -p backend/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68571d44bc50832cbd4b3ee085807532