### PR TITLE
Add Jest e2e tests

### DIFF
--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,0 +1,1 @@
+JWT_SECRET=supersecret

--- a/backend/jest-e2e.json
+++ b/backend/jest-e2e.json
@@ -1,0 +1,10 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "./",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "setupFiles": ["<rootDir>/test/setup-env.ts"],
+  "testEnvironment": "node"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,30 +5,39 @@
   "scripts": {
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "build": "nest build"
+    "build": "nest build",
+    "test:e2e": "jest --config jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
-    "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/swagger": "^7.0.0",
     "@nestjs/config": "^3.0.0",
-    "@nestjs/typeorm": "^10.0.0",
-    "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1",
-    "typeorm": "^0.3.17",
-    "pg": "^8.10.0",
+    "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "bcrypt": "^5.1.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
-    "bcrypt": "^5.1.0",
-    "class-validator": "^0.14.0"
+    "pg": "^8.10.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "sqlite3": "^5.1.7",
+    "typeorm": "^0.3.17"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
-    "typescript": "^5.1.3",
-    "@types/node": "^18.0.0"
+    "@nestjs/testing": "^10.0.0",
+    "@types/jest": "^29.5.3",
+    "@types/node": "^18.0.0",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.6.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.1.3"
   }
 }

--- a/backend/src/todo/dto/create-todo.dto.ts
+++ b/backend/src/todo/dto/create-todo.dto.ts
@@ -1,9 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsBoolean, IsOptional } from 'class-validator';
 
 export class CreateTodoDto {
   @ApiProperty({ example: 'Buy milk', description: 'Title of the todo item' })
+  @IsString()
   title: string;
 
   @ApiProperty({ example: false, description: 'Completion status', required: false })
+  @IsBoolean()
+  @IsOptional()
   completed?: boolean;
 }

--- a/backend/test/app.factory.ts
+++ b/backend/test/app.factory.ts
@@ -1,0 +1,35 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { TenantInterceptor } from '../src/tenant.interceptor';
+import { AuthModule } from '../src/auth/auth.module';
+import { TenantModule } from '../src/tenant/tenant.module';
+import { TodoModule } from '../src/todo/todo.module';
+import { Tenant } from '../src/entities/tenant.entity';
+import { User } from '../src/entities/user.entity';
+import { Todo } from '../src/entities/todo.entity';
+
+export async function createTestApp(): Promise<INestApplication> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env.test' }),
+      TypeOrmModule.forRoot({
+        type: 'sqlite',
+        database: ':memory:',
+        dropSchema: true,
+        entities: [Tenant, User, Todo],
+        synchronize: true,
+      }),
+      AuthModule,
+      TenantModule,
+      TodoModule,
+    ],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useGlobalInterceptors(new TenantInterceptor());
+  await app.init();
+  return app;
+}

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,45 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp } from './app.factory';
+
+describe('Auth (e2e)', () => {
+  let app: INestApplication;
+  let tenantId: number;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    const res = await request(app.getHttpServer())
+      .post('/tenants')
+      .send({ name: 'Test Tenant' })
+      .expect(201);
+    tenantId = res.body.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('Yeni kullanıcı kayıt olabiliyor mu?', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({
+        username: 'gokhan',
+        email: 'gokhan@example.com',
+        password: '123456',
+        tenantId,
+      })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body.password).not.toBe('123456');
+  });
+
+  it('Kullanıcı login olup JWT token alabiliyor mu?', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'gokhan@example.com', password: '123456' })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('accessToken');
+  });
+});

--- a/backend/test/setup-env.ts
+++ b/backend/test/setup-env.ts
@@ -1,0 +1,2 @@
+import { config } from 'dotenv';
+config({ path: '.env.test' });

--- a/backend/test/tenant.e2e-spec.ts
+++ b/backend/test/tenant.e2e-spec.ts
@@ -1,0 +1,25 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp } from './app.factory';
+
+describe('Tenant (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('Tenant oluşturulabiliyor mu?', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/tenants')
+      .send({ name: 'Test Tenant' })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('name', 'Test Tenant');
+  });
+});

--- a/backend/test/todo.e2e-spec.ts
+++ b/backend/test/todo.e2e-spec.ts
@@ -1,0 +1,59 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp } from './app.factory';
+
+describe('Todo (e2e)', () => {
+  let app: INestApplication;
+  let tenantId: number;
+  let token: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    const tenant = await request(app.getHttpServer())
+      .post('/tenants')
+      .send({ name: 'Test Tenant' })
+      .expect(201);
+    tenantId = tenant.body.id;
+
+    await request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({
+        username: 'gokhan',
+        email: 'gokhan@example.com',
+        password: '123456',
+        tenantId,
+      })
+      .expect(201);
+
+    const login = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'gokhan@example.com', password: '123456' })
+      .expect(201);
+    token = login.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('JWT ile todo kaydı yapılabiliyor mu?', async () => {
+    const res = await request(app.getHttpServer())
+      .post(`/todos?tenantId=${tenantId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Buy milk', completed: false })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toMatchObject({ title: 'Buy milk', completed: false, tenantId });
+  });
+
+  it('JWT ile todo listesi çekilebiliyor mu?', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/todos?tenantId=${tenantId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest configuration for e2e tests
- create `.env.test` for test environment
- add helper factory to spin up NestJS app with in-memory sqlite
- add e2e tests for tenant, auth and todo modules
- ensure todo DTO uses validation decorators for whitelist

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68573c915d80832c8f8590c1e6f8a109