### PR TITLE
Fix axios baseURL and add dev proxy

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,9 +1,9 @@
-import api from './axios';
+import client from './client';
 
 export async function signup(data: { username: string; email: string; password: string; tenantId: number }) {
-  return (await api.post('/auth/signup', data)).data;
+  return (await client.post('/auth/signup', data)).data;
 }
 
 export async function login(data: { email: string; password: string }) {
-  return (await api.post('/auth/login', data)).data;
+  return (await client.post('/auth/login', data)).data;
 }

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:3000',
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: true,
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: true,
+});
+
+export default client;

--- a/frontend/src/api/todo.ts
+++ b/frontend/src/api/todo.ts
@@ -1,11 +1,11 @@
-import api from './axios';
+import client from './client';
 
 export async function fetchTodos(tenantId: number) {
-  const { data } = await api.get(`/todos`, { params: { tenantId } });
+  const { data } = await client.get(`/todos`, { params: { tenantId } });
   return data;
 }
 
 export async function addTodo(tenantId: number, title: string) {
-  const { data } = await api.post(`/todos?tenantId=${tenantId}`, { title });
+  const { data } = await client.post(`/todos?tenantId=${tenantId}`, { title });
   return data;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      '/auth': 'http://localhost:3000',
+      '/admin': 'http://localhost:3000',
+      '/todo': 'http://localhost:3000',
+      '/tenants': 'http://localhost:3000',
+    },
   },
 });


### PR DESCRIPTION
## Summary
- proxy `/auth`, `/admin`, `/todo`, and `/tenants` to the backend in `vite.config.ts`
- configure axios base URL with `VITE_API_URL`
- create API client using env config
- update auth and todo modules to use the new client
- add `.env` for local development

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6857f2c88534832c92f682d56fc5a222