### PR TITLE
Fix login withCredentials

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -5,5 +5,5 @@ export async function signup(data: { username: string; email: string; password: 
 }
 
 export async function login(data: { email: string; password: string }) {
-  return (await client.post('/auth/login', data)).data;
+  return (await client.post('/auth/login', data, { withCredentials: true })).data;
 }


### PR DESCRIPTION
## Summary
- include `withCredentials` in login API call

## Testing
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fc000c54832cb1799e343584aa4a