### PR TITLE
Add admin layout with role-based routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,10 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import Signup from './pages/Signup';
-import Login from './pages/Login';
-import Todos from './pages/Todos';
+import Router from './router';
+import { AuthProvider } from './context/AuthContext';
 
-function App() {
+export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/todos" element={<Todos />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <Router />
+    </AuthProvider>
   );
 }
-
-export default App;

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,20 @@
+import { NavLink } from 'react-router-dom';
+
+export default function Sidebar() {
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `block p-2 rounded ${isActive ? 'bg-gray-300 font-bold' : ''}`;
+
+  return (
+    <div className="w-48 bg-gray-200 min-h-screen p-4 space-y-2">
+      <NavLink to="/admin/dashboard" className={linkClass} end>
+        Dashboard
+      </NavLink>
+      <NavLink to="/admin/tables" className={linkClass}>
+        Tables
+      </NavLink>
+      <NavLink to="/admin/settings" className={linkClass}>
+        Settings
+      </NavLink>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+export default function Topbar() {
+  const { role, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const onLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <div className="bg-gray-800 text-white p-4 flex justify-between">
+      <div className="font-bold">
+        {role === 'admin' ? 'Admin Panel' : 'Todo App'}
+      </div>
+      <button onClick={onLogout} className="text-sm hover:underline">
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type AuthContextType = {
+  token: string | null;
+  role: string | null;
+  login: (token: string) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType>({
+  token: null,
+  role: null,
+  login: () => {},
+  logout: () => {},
+});
+
+function parseRole(token: string): string | null {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.role ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) {
+      setToken(stored);
+      setRole(parseRole(stored));
+    }
+  }, []);
+
+  const login = (jwt: string) => {
+    localStorage.setItem('token', jwt);
+    setToken(jwt);
+    setRole(parseRole(jwt));
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+    setRole(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, role, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,23 +1,39 @@
 import { useState } from 'react';
-import { login } from '../api/auth';
+import { login as loginRequest } from '../api/auth';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 export default function Login() {
   const navigate = useNavigate();
+  const { login } = useAuth();
   const [form, setForm] = useState({ email: '', password: '' });
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await login(form);
-    localStorage.setItem('token', res.accessToken);
-    navigate('/todos');
+    const res = await loginRequest(form);
+    login(res.accessToken);
+    const { role } = JSON.parse(atob(res.accessToken.split('.')[1]));
+    navigate(role === 'admin' ? '/admin/dashboard' : '/todos');
   };
 
   return (
     <form className="p-4 space-y-2" onSubmit={onSubmit}>
-      <input className="border p-2 w-full" placeholder="Email" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
-      <input className="border p-2 w-full" type="password" placeholder="Password" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} />
-      <button className="bg-blue-500 text-white px-4 py-2" type="submit">Login</button>
+      <input
+        className="border p-2 w-full"
+        placeholder="Email"
+        value={form.email}
+        onChange={e => setForm({ ...form, email: e.target.value })}
+      />
+      <input
+        className="border p-2 w-full"
+        type="password"
+        placeholder="Password"
+        value={form.password}
+        onChange={e => setForm({ ...form, password: e.target.value })}
+      />
+      <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+        Login
+      </button>
     </form>
   );
 }

--- a/frontend/src/pages/admin/Dashboard.tsx
+++ b/frontend/src/pages/admin/Dashboard.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Dashboard() {
+  return <h1 className="text-2xl font-bold">Admin Dashboard</h1>;
+}

--- a/frontend/src/pages/admin/Settings.tsx
+++ b/frontend/src/pages/admin/Settings.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Settings() {
+  return <h1 className="text-2xl font-bold">Admin Settings</h1>;
+}

--- a/frontend/src/pages/admin/Tables.tsx
+++ b/frontend/src/pages/admin/Tables.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Tables() {
+  return <h1 className="text-2xl font-bold">Admin Tables</h1>;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,94 @@
+import { BrowserRouter, Navigate, Outlet, useRoutes } from 'react-router-dom';
+import Signup from './pages/Signup';
+import Login from './pages/Login';
+import Todos from './pages/Todos';
+import Dashboard from './pages/admin/Dashboard';
+import Tables from './pages/admin/Tables';
+import Settings from './pages/admin/Settings';
+import Sidebar from './components/layout/Sidebar';
+import Topbar from './components/layout/Topbar';
+import { useAuth } from './context/AuthContext';
+
+function RequireAuth({ children }: { children: JSX.Element }) {
+  const { token } = useAuth();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}
+
+function RequireAdmin({ children }: { children: JSX.Element }) {
+  const { token, role } = useAuth();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  if (role !== 'admin') {
+    return <Navigate to="/todos" replace />;
+  }
+  return children;
+}
+
+function AdminLayout() {
+  return (
+    <div className="flex">
+      <Sidebar />
+      <div className="flex-1">
+        <Topbar />
+        <div className="p-4">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TodoLayout() {
+  return (
+    <div>
+      <Topbar />
+      <div className="p-4">
+        <Todos />
+      </div>
+    </div>
+  );
+}
+
+function AppRoutes() {
+  const routes = useRoutes([
+    { path: '/signup', element: <Signup /> },
+    { path: '/login', element: <Login /> },
+    {
+      path: '/todos',
+      element: (
+        <RequireAuth>
+          <TodoLayout />
+        </RequireAuth>
+      ),
+    },
+    {
+      path: '/admin',
+      element: (
+        <RequireAdmin>
+          <AdminLayout />
+        </RequireAdmin>
+      ),
+      children: [
+        { path: 'dashboard', element: <Dashboard /> },
+        { path: 'tables', element: <Tables /> },
+        { path: 'settings', element: <Settings /> },
+        { index: true, element: <Navigate to="dashboard" replace /> },
+      ],
+    },
+    { path: '*', element: <Navigate to="/login" replace /> },
+  ]);
+
+  return routes;
+}
+
+export default function Router() {
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
## Summary
- create admin pages and layout components
- implement AuthContext with role support
- add router with role-based route guards
- update login flow and App entrypoint

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862c3d43c84832cb93e6bdad4c5d6fb