### PR TITLE
Enhance UI roles and admin logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Minimal ITSM + GRC starter project using NestJS and React.
 ## Getting Started
 1. Create a `.env` file based on `.env.example`.
 2. Run database migrations or load `schema.sql`.
+   - `cd backend && npm run migration:run`
 3. Install dependencies in both `backend` and `frontend`.
 4. Start the backend and frontend development servers.
    - `cd backend && npm install && npm run start:dev`
    - `cd frontend && npm install && npm run dev`
    - Or simply run `./scripts/start.sh` and `./scripts/stop.sh` to manage both
      servers together.
+5. Use the admin panel to view logs and manage roles once logged in as admin.
+
 

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -4,6 +4,8 @@ import { Roles } from '../roles.decorator';
 import { RolesGuard } from '../roles.guard';
 import { AuthGuard } from '@nestjs/passport';
 import { DotWalkingService } from '../dotwalking.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { AssignRoleDto } from './dto/assign-role.dto';
 
 @Controller('admin')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -30,14 +32,14 @@ export class AdminController {
 
   @Post('roles')
   @Roles('Admin')
-  createRole(@Body('name') name: string) {
-    return this.adminService.createRole(name);
+  createRole(@Body() dto: CreateRoleDto) {
+    return this.adminService.createRole(dto.name);
   }
 
   @Post('users/:id/roles')
   @Roles('Admin')
-  assignRole(@Param('id') id: number, @Body('role') role: string) {
-    return this.adminService.assignRole(id, role);
+  assignRole(@Param('id') id: number, @Body() dto: AssignRoleDto) {
+    return this.adminService.assignRole(id, dto.role);
   }
 
   @Get('config')
@@ -59,3 +61,4 @@ export class AdminController {
     return this.adminService.getLogs(Number(tenantId));
   }
 }
+

--- a/backend/src/admin/dto/assign-role.dto.ts
+++ b/backend/src/admin/dto/assign-role.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class AssignRoleDto {
+  @IsString()
+  @IsNotEmpty()
+  role: string;
+}
+

--- a/backend/src/admin/dto/create-role.dto.ts
+++ b/backend/src/admin/dto/create-role.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class CreateRoleDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}
+

--- a/backend/src/roles.guard.ts
+++ b/backend/src/roles.guard.ts
@@ -22,11 +22,22 @@ export class RolesGuard implements CanActivate {
     const rolesCount = await this.rolesRepo.count();
     if (rolesCount === 0) return true;
     const { user } = context.switchToHttp().getRequest();
-    if (!user || !user.roles || user.roles.length === 0) {
-      // allow first role assignment scenario
+    if (!user) return false;
+
+    const userRoles: string[] = [];
+    if (user.roles && Array.isArray(user.roles)) {
+      userRoles.push(...user.roles);
+    }
+    if (user.role) {
+      userRoles.push(user.role);
+    }
+
+    if (userRoles.length === 0) {
       if (rolesCount === 1) return true;
       return false;
     }
-    return requiredRoles.some((role) => user.roles.includes(role));
+
+    return requiredRoles.some((r) => userRoles.includes(r));
   }
 }
+

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,0 +1,7 @@
+import client from './client';
+
+export async function fetchLogs(tenantId: number) {
+  const { data } = await client.get(`/admin/logs`, { params: { tenantId } });
+  return data;
+}
+

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,4 +5,20 @@ const client = axios.create({
   withCredentials: true,
 });
 
+client.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response) {
+      const status = err.response.status;
+      if (status === 401) {
+        window.location.href = '/unauthorized';
+      } else if (status === 403) {
+        window.location.href = '/forbidden';
+      }
+    }
+    return Promise.reject(err);
+  },
+);
+
 export default client;
+

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { NavLink } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 
 export default function Sidebar() {
+  const { role } = useAuth();
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `block p-2 rounded ${isActive ? 'bg-gray-300 font-bold' : ''}`;
 
@@ -9,15 +11,23 @@ export default function Sidebar() {
       <NavLink to="/todos" className={linkClass}>
         Todos
       </NavLink>
-      <NavLink to="/admin/dashboard" className={linkClass} end>
-        Dashboard
-      </NavLink>
-      <NavLink to="/admin/tables" className={linkClass}>
-        Tables
-      </NavLink>
-      <NavLink to="/admin/settings" className={linkClass}>
-        Settings
-      </NavLink>
+      {role === 'admin' && (
+        <>
+          <NavLink to="/admin/dashboard" className={linkClass} end>
+            Dashboard
+          </NavLink>
+          <NavLink to="/admin/tables" className={linkClass}>
+            Tables
+          </NavLink>
+          <NavLink to="/admin/settings" className={linkClass}>
+            Settings
+          </NavLink>
+          <NavLink to="/admin/logs" className={linkClass}>
+            Logs
+          </NavLink>
+        </>
+      )}
     </div>
   );
 }
+

--- a/frontend/src/pages/Forbidden.tsx
+++ b/frontend/src/pages/Forbidden.tsx
@@ -1,0 +1,9 @@
+export default function Forbidden() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-2">Forbidden</h1>
+      <p>You do not have permission to access this page.</p>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -12,6 +12,10 @@ export default function Login() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!form.email || !form.password) {
+      setError('Email and password are required');
+      return;
+    }
     setError(null);
     setLoading(true);
     try {
@@ -48,3 +52,4 @@ export default function Login() {
     </form>
   );
 }
+

--- a/frontend/src/pages/Unauthorized.tsx
+++ b/frontend/src/pages/Unauthorized.tsx
@@ -1,0 +1,9 @@
+export default function Unauthorized() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-2">Unauthorized</h1>
+      <p>You are not authorized to access this page.</p>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/admin/Logs.tsx
+++ b/frontend/src/pages/admin/Logs.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { fetchLogs } from '../../api/admin';
+
+export default function Logs() {
+  const [logs, setLogs] = useState<any[] | null>(null);
+  const tenantId = 1;
+
+  useEffect(() => {
+    fetchLogs(tenantId).then(setLogs);
+  }, []);
+
+  if (logs === null) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Logs</h1>
+      {logs.length === 0 ? (
+        <div>No logs</div>
+      ) : (
+        <ul className="space-y-2">
+          {logs.map((l) => (
+            <li key={l.id} className="border p-2 rounded">
+              {l.method} {l.path}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,9 @@ import Todos from './pages/Todos';
 import Dashboard from './pages/admin/Dashboard';
 import Tables from './pages/admin/Tables';
 import Settings from './pages/admin/Settings';
+import Logs from './pages/admin/Logs';
+import Unauthorized from './pages/Unauthorized';
+import Forbidden from './pages/Forbidden';
 import Sidebar from './components/layout/Sidebar';
 import Topbar from './components/layout/Topbar';
 import { useAuth } from './context/AuthContext';
@@ -34,10 +37,13 @@ function AdminLayout() {
 
 function TodoLayout() {
   return (
-    <div>
-      <Topbar />
-      <div className="p-4">
-        <Todos />
+    <div className="flex">
+      <Sidebar />
+      <div className="flex-1">
+        <Topbar />
+        <div className="p-4">
+          <Todos />
+        </div>
       </div>
     </div>
   );
@@ -47,6 +53,8 @@ function AppRoutes() {
   const routes = useRoutes([
     { path: '/signup', element: <Signup /> },
     { path: '/login', element: <Login /> },
+    { path: '/unauthorized', element: <Unauthorized /> },
+    { path: '/forbidden', element: <Forbidden /> },
     {
       path: '/todos',
       element: (
@@ -66,6 +74,7 @@ function AppRoutes() {
         { path: 'dashboard', element: <Dashboard /> },
         { path: 'tables', element: <Tables /> },
         { path: 'settings', element: <Settings /> },
+        { path: 'logs', element: <Logs /> },
         { index: true, element: <Navigate to="dashboard" replace /> },
       ],
     },


### PR DESCRIPTION
## Summary
- show sidebar for all roles and hide admin links for non-admins
- add unauthorized/forbidden pages and redirect via Axios
- include admin logs page and API
- improve login form validation
- support single-role tokens in `RolesGuard`
- add DTOs for role operations
- document migration usage in README

## Testing
- `bash scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6862f475331c832cb5713febfa0e86f2