### PR TITLE
Fix sidebar duplication logic

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,8 +1,6 @@
 import { NavLink } from 'react-router-dom';
-import { useAuth } from '../../context/AuthContext';
 
 export default function Sidebar() {
-  const { role } = useAuth();
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `block p-2 rounded ${isActive ? 'bg-gray-300 font-bold' : ''}`;
 


### PR DESCRIPTION
## Summary
- simplify Sidebar links so each link appears once regardless of user role

## Testing
- `npm test` in `frontend`
- `npm test` in `backend` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa023f94832cb31783015980a5a2